### PR TITLE
Optional priorities for artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 
 rvm:
-  - 2.1.4
+  - 2.2.0
 
 bundler_args: --without integration development

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 
 rvm:
-  - 2.2.0
+  - 2.2.5
 
 bundler_args: --without integration development

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "maurizio@session.it"
 license           "Apache 2.0"
 description       "A Chef Cookbook that provides a simple way to download, unpack and configure artifacts"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "0.8.19"
+version           "0.9.0"
 
 supports          "ubuntu-12.04"
 supports          "centos-6.6"

--- a/recipes/artifacts.rb
+++ b/recipes/artifacts.rb
@@ -38,7 +38,13 @@ end
 pathPrefix = node['artifactPathPrefix']
 
 unless node['artifacts'] == nil
-  node['artifacts'].each do |artifactName, artifact|
+  # Add default priority if it's missing
+  node['artifacts'].each do | artifactName, artifact |
+    unless artifact.has_key?('priority')
+      node['artifacts'][artifactName]['priority'] = 10
+    end
+  end
+  node['artifacts'].sort_by { |k, v| v[:priority] }.to_h.each do |artifactName, artifact|
     url             = artifact[:url]
     path            = artifact[:path] ? "#{pathPrefix}/#{artifact[:path]}" : nil
     artifact_id     = artifact[:artifactId]

--- a/recipes/artifacts.rb
+++ b/recipes/artifacts.rb
@@ -41,7 +41,7 @@ unless node['artifacts'] == nil
   # Add default priority if it's missing
   node['artifacts'].each do | artifactName, artifact |
     unless artifact.has_key?('priority')
-      node['artifacts'][artifactName]['priority'] = 10
+      node.default['artifacts'][artifactName]['priority'] = 10
     end
   end
   node['artifacts'].sort_by { |k, v| v[:priority] }.to_h.each do |artifactName, artifact|


### PR DESCRIPTION
Priorities can now be set to enforce order in which artifacts are deployed. Default priority is 10. 

Bumped version to 0.9.0 (new functionality, backwards compatible, hence minor version increase).
